### PR TITLE
Centralize Go API configuration loading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ SWAGGER_HOST=localhost:8080
 VITE_TESTING=true
 ```
 
+The Go API configuration is centralized in `src/config`. It loads `.env` files, environment variables, and command-line flags. You can override settings with flags such as `--grpc-server-address`, `--swagger-host`, or `--config /path/to/.env` when running the API.
+
 #### 3. Manually Download Project Assets (Models & Data)
 This project requires pre-trained models and a data file to function correctly. You must download these assets manually.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ BBE is designed with a modern, decoupled, multi-container architecture, enabling
 
 For detailed instructions on running Blue Banner Engine locally or contributing to the project, please see our [CONTRIBUTING.md](https://github.com/armandomm09/blue-banner-engine?tab=contributing-ov-file) guide.
 
+Configuration for the Go API is centralized in `src/config`, which loads `.env` files, environment variables, and command-line flags in one place.
+
 
 
 ## License
@@ -113,6 +115,5 @@ This project is licensed under the MIT License - see the `LICENSE` file for deta
 
 -   **Pablo Armando Mac Beath Milián**
 -   **Rene Cumplido Feregrino**
-
 
 

--- a/main.go
+++ b/main.go
@@ -17,12 +17,12 @@ import (
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
-	"github.com/joho/godotenv"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"blue-banner-engine/src/config"
 	"blue-banner-engine/src/routes"
 )
 
@@ -80,22 +80,17 @@ type TbaEvent struct {
 // @BasePath  /api/v1
 func main() {
 
-	err := godotenv.Load() // Load .env file from current directory
+	cfg, err := config.Load()
 	if err != nil {
-		log.Println("Error loading .env file")
+		log.Fatalf("Config error: %v", err)
 	}
-	tbaKey := os.Getenv("TBA_API_KEY")
-	if tbaKey == "" {
+
+	if cfg.TBAAPIKey == "" {
 		log.Println("WARNING: TBA_API_KEY environment variable not set. Real match data will not be available.")
 	}
 
-	grpcServerAddress := os.Getenv("GRPC_SERVER_ADDRESS")
-	if grpcServerAddress == "" {
-		grpcServerAddress = "localhost:50051"
-	}
-
 	// gRPC Client Configuration
-	conn, err := grpc.Dial(grpcServerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(cfg.GRPCServerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}
@@ -103,7 +98,7 @@ func main() {
 
 	handler := &PredictionHandler{
 		grpcClient: pb.NewMatchpointClient(conn),
-		tbaApiKey:  tbaKey,
+		tbaApiKey:  cfg.TBAAPIKey,
 	}
 	analyticsClient := pb_analytics.NewAnalyticsClient(conn)
 
@@ -119,17 +114,13 @@ func main() {
 	}))
 
 	// Configure Swagger host based on environment variable
-	swaggerHost := os.Getenv("SWAGGER_HOST")
-	if swaggerHost == "" {
-		swaggerHost = "localhost:8080" // default
-	}
-	docs.SwaggerInfo.Host = swaggerHost
+	docs.SwaggerInfo.Host = cfg.SwaggerHost
 	docs.SwaggerInfo.BasePath = "/api/v1"
 
 	v1 := router.Group("/api/v1")
 	{
-		routes.RegisterMatchpointRoutes(v1, handler.grpcClient, tbaKey)
-		routes.RegisterTbaRoutes(v1, tbaKey)
+		routes.RegisterMatchpointRoutes(v1, handler.grpcClient, cfg.TBAAPIKey)
+		routes.RegisterTbaRoutes(v1, cfg.TBAAPIKey)
 		routes.RegisterSimulationRoutes(v1, handler.grpcClient)
 		routes.RegisterAnalyticsRoutes(v1, analyticsClient)
 
@@ -181,11 +172,9 @@ func main() {
 	log.Println("Access the UI at https://bbe-frc.com")
 	log.Println("API documentation at https://bbe-frc.com/swagger/index.html")
 
-	if os.Getenv("PRODUCTION") == "true" &&
-		os.Getenv("CERT_PATH") != "" &&
-		os.Getenv("KEY_PATH") != "" {
+	if cfg.Production {
 		log.Println("Running on production")
-		router.RunTLS(":8080", os.Getenv("CERT_PATH"), os.Getenv("KEY_PATH"))
+		router.RunTLS(":8080", cfg.CertPath, cfg.KeyPath)
 	} else {
 		log.Println("Running on testing")
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/joho/godotenv"
+)
+
+type Config struct {
+	ConfigFile        string
+	TBAAPIKey         string
+	GRPCServerAddress string
+	SwaggerHost       string
+	Production        bool
+	CertPath          string
+	KeyPath           string
+}
+
+func Load() (*Config, error) {
+	args := os.Args[1:]
+	configPath, configExplicit := configPathFromArgs(args)
+	if configPath != "" {
+		if _, err := os.Stat(configPath); err != nil {
+			if configExplicit {
+				return nil, fmt.Errorf("config file %s not found", configPath)
+			}
+		} else if err := godotenv.Load(configPath); err != nil {
+			return nil, fmt.Errorf("load config file %s: %w", configPath, err)
+		}
+	}
+
+	grpcDefault := envString("GRPC_SERVER_ADDRESS", "localhost:50051")
+	swaggerDefault := envString("SWAGGER_HOST", "localhost:8080")
+	productionDefault, err := envBool("PRODUCTION")
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &Config{
+		ConfigFile:        configPath,
+		TBAAPIKey:         os.Getenv("TBA_API_KEY"),
+		GRPCServerAddress: grpcDefault,
+		SwaggerHost:       swaggerDefault,
+		Production:        productionDefault,
+		CertPath:          os.Getenv("CERT_PATH"),
+		KeyPath:           os.Getenv("KEY_PATH"),
+	}
+
+	flagSet := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	flagSet.SetOutput(io.Discard)
+
+	flagSet.StringVar(&cfg.ConfigFile, "config", cfg.ConfigFile, "Path to a .env config file")
+	flagSet.StringVar(&cfg.TBAAPIKey, "tba-api-key", cfg.TBAAPIKey, "TBA API key")
+	flagSet.StringVar(&cfg.GRPCServerAddress, "grpc-server-address", cfg.GRPCServerAddress, "Address of the gRPC server")
+	flagSet.StringVar(&cfg.SwaggerHost, "swagger-host", cfg.SwaggerHost, "Swagger host value")
+	flagSet.BoolVar(&cfg.Production, "production", cfg.Production, "Run in production mode")
+	flagSet.StringVar(&cfg.CertPath, "cert-path", cfg.CertPath, "TLS certificate path (required in production)")
+	flagSet.StringVar(&cfg.KeyPath, "key-path", cfg.KeyPath, "TLS key path (required in production)")
+
+	if err := flagSet.Parse(args); err != nil {
+		return nil, err
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func (c *Config) Validate() error {
+	var issues []string
+	if c.GRPCServerAddress == "" {
+		issues = append(issues, "GRPC_SERVER_ADDRESS is required")
+	}
+	if c.SwaggerHost == "" {
+		issues = append(issues, "SWAGGER_HOST is required")
+	}
+	if c.Production {
+		if c.CertPath == "" {
+			issues = append(issues, "CERT_PATH is required when PRODUCTION is true")
+		}
+		if c.KeyPath == "" {
+			issues = append(issues, "KEY_PATH is required when PRODUCTION is true")
+		}
+	}
+	if len(issues) > 0 {
+		return errors.New(strings.Join(issues, "; "))
+	}
+	return nil
+}
+
+func envString(key, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func envBool(key string) (bool, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return false, nil
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("invalid %s value %q: %w", key, value, err)
+	}
+	return parsed, nil
+}
+
+func configPathFromArgs(args []string) (string, bool) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case strings.HasPrefix(arg, "--config="):
+			return strings.TrimPrefix(arg, "--config="), true
+		case strings.HasPrefix(arg, "-config="):
+			return strings.TrimPrefix(arg, "-config="), true
+		case arg == "--config" || arg == "-config":
+			if i+1 < len(args) {
+				return args[i+1], true
+			}
+		}
+	}
+	return ".env", false
+}


### PR DESCRIPTION
### Motivation
- Remove scattered uses of `os.Getenv` and `.env` loading from `main.go` and centralize configuration management.
- Provide a typed `Config` schema that consolidates env variables, `.env` files and command-line flags in one place.
- Validate required fields (especially production TLS fields) early with clear error messages to avoid runtime misconfiguration.

### Description
- Add a new package `src/config` with `Config` and `Load()` which reads `.env` files (via `--config`), environment variables, and flags like `--grpc-server-address` and `--swagger-host` and returns a validated config.
- Wire the loader into `main.go` to replace direct `os.Getenv` usage and pass `cfg.TBAAPIKey`, `cfg.GRPCServerAddress`, `cfg.SwaggerHost`, and TLS settings into server setup and route registration.
- Improve `--config` handling to error when an explicit config file is missing and keep `.env` as the default when not explicitly provided.
- Update `README.md` and `CONTRIBUTING.md` to document the new `src/config` location and available flags.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696413a4ea90833392a9bc8e8e5bc4d2)